### PR TITLE
glibc: arc: Fix case statement

### DIFF
--- a/sysdeps/arc/preconfigure
+++ b/sysdeps/arc/preconfigure
@@ -2,7 +2,6 @@ case "$machine" in
 arc*)
   base_machine=arc
   machine=arc
-  ;;
 
   gccfloat=`$CC $CFLAGS $CPPFLAGS -E -dM -xc /dev/null | grep __ARC_FPU_| wc -l`
   if test "$gccfloat" != "0"; then
@@ -11,5 +10,6 @@ arc*)
   else
     with_fp_cond=0
   fi
+  ;;
 
 esac


### PR DESCRIPTION
When the preconfigure fix was ported from crosstool-NG the ';;' was misplaced. Fix this now.

Fixes: b9c761539b2 ("glibc: arc: Don't interfere with other architectures")

Signed-off-by: Chris Packham <judge.packham@gmail.com>