### PR TITLE
locale/tst-locale-locpath: Run test only for $(run-built-tests) == yes

### DIFF
--- a/locale/Makefile
+++ b/locale/Makefile
@@ -28,7 +28,6 @@ routines	= setlocale findlocale loadlocale loadarchive \
 		  localeconv nl_langinfo nl_langinfo_l mb_cur_max \
 		  newlocale duplocale freelocale uselocale
 tests		= tst-C-locale tst-locname tst-duplocale
-tests-special	= $(objpfx)tst-locale-locpath.out
 categories	= ctype messages monetary numeric time paper name \
 		  address telephone measurement identification collate
 aux		= $(categories:%=lc-%) $(categories:%=C-%) SYS_libc C_name \
@@ -62,6 +61,14 @@ lib-modules		:= charmap-dir simple-hash xmalloc xstrdup \
 
 GPERF = gperf
 GPERFFLAGS = -acCgopt -k1,2,5,9,$$ -L ANSI-C
+
+ifeq ($(run-built-tests),yes)
+tests-special += $(objpfx)tst-locale-locpath.out
+endif
+
+ifeq ($(run-built-tests),yes)
+tests-special += $(objpfx)tst-locale-locpath.out
+endif
 
 include ../Rules
 


### PR DESCRIPTION
This patch fixes the problem of broken glibcs check step.

From: Florian Weimer <fweimer@redhat.com>
Signed-off-by: Nikita Sobolev <Nikita.Sobolev@synopsys.com>