### PR TITLE
ARC:fpu: add extra capability check before use of sqrt and fma builtins

### DIFF
--- a/sysdeps/arc/fpu/math-use-builtins-fma.h
+++ b/sysdeps/arc/fpu/math-use-builtins-fma.h
@@ -1,4 +1,18 @@
-#define USE_FMA_BUILTIN 1
-#define USE_FMAF_BUILTIN 1
+#if defined __ARCV3__
+# define USE_FMA_BUILTIN 1
+# define USE_FMAF_BUILTIN 1
+#else
+# if defined __ARC_FPU_DP_FMA__
+#  define USE_FMA_BUILTIN 1
+# else
+#  define USE_FMA_BUILTIN 0
+# endif
+# if defined __ARC_FPU_SP_FMA__
+#  define USE_FMAF_BUILTIN 1
+# else
+#  define USE_FMAF_BUILTIN 0
+# endif
+#endif
+
 #define USE_FMAL_BUILTIN 0
 #define USE_FMAF128_BUILTIN 0

--- a/sysdeps/arc/fpu/math-use-builtins-sqrt.h
+++ b/sysdeps/arc/fpu/math-use-builtins-sqrt.h
@@ -1,4 +1,18 @@
-#define USE_SQRT_BUILTIN 1
-#define USE_SQRTF_BUILTIN 1
+#if defined __ARCV3__
+# define USE_SQRT_BUILTIN 1
+# define USE_SQRTF_BUILTIN 1
+#else
+# if defined __ARC_FPU_DP_DIV__
+#  define USE_SQRT_BUILTIN 1
+# else
+#  define USE_SQRT_BUILTIN 0
+# endif
+# if defined __ARC_FPU_SP_DIV__
+#  define USE_SQRTF_BUILTIN 1
+# else
+#  define USE_SQRTF_BUILTIN 0
+# endif
+#endif
+
 #define USE_SQRTL_BUILTIN 0
 #define USE_SQRTF128_BUILTIN 0


### PR DESCRIPTION
For ARCHS add extra check for compiler definitions to ensure that compiler provides sqrt and fma hw fpu instructions else use software implementation. ARCv3 does not require these checks.
Fix for issue #15 